### PR TITLE
MT-3334: add onNotificatoinOpenedApp listener

### DIFF
--- a/android/app/src/main/java/com/rntest/MainActivity.java
+++ b/android/app/src/main/java/com/rntest/MainActivity.java
@@ -1,8 +1,17 @@
 package com.rntest;
 
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+
+import io.invertase.firebase.common.ReactNativeFirebaseEventEmitter;
+import io.invertase.firebase.messaging.ReactNativeFirebaseMessagingSerializer;
 
 public class MainActivity extends ReactActivity {
 
@@ -43,6 +52,29 @@ public class MainActivity extends ReactActivity {
       // If you opted-in for the New Architecture, we enable Concurrent Root (i.e. React 18).
       // More on this on https://reactjs.org/blog/2022/03/29/react-v18.html
       return BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+    }
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    processIntent(getIntent());
+  }
+
+  @Override
+  public void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
+    processIntent(intent);
+  }
+
+  private void processIntent(Intent intent) {
+    // Check if the Intent is coming from AIQUA via customized key-value pair.
+    // Please ensure you have set the "Include Key-Value Pairs" option in the campaign settings on the AIQUA dashboard,
+    // with the key-value pair "key=source, value=aiqua".
+    if (intent != null && "aiqua".equals(intent.getStringExtra("source"))) {
+      ReactNativeFirebaseEventEmitter emitter = ReactNativeFirebaseEventEmitter.getSharedInstance();
+      WritableMap extras = Arguments.fromBundle(intent.getExtras());
+      emitter.sendEvent(ReactNativeFirebaseMessagingSerializer.remoteMessageMapToEvent(extras, true));
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ if (Platform.OS === 'android') {
       }
     }
   });
+
+  messaging().onNotificationOpenedApp(qgPayload => {
+    console.log('Notification Open App:', qgPayload);
+  });
 }
 
 AppRegistry.registerComponent(appName, () => App);


### PR DESCRIPTION
## Change
Add the ``onNotificatoinOpenedApp`` listener. Users can receive the event with a customized payload when user open a notification.

## How to verify this behavior

1. Go to the campaign settings on the AIQUA dashboard.
2. Check the "Include Key-Value Pairs" option and add a key-value pair "key=source, value=aiqua".
<img width="472" alt="Screen Shot 2023-05-30 at 2 42 46 PM" src="https://github.com/appier/react-native-sample-app/assets/10951814/7306bc80-1d62-428c-bde2-f38c19938713">

3. Sent a campaign without deeplink, click the notification, then you should able to see the log "Notification Open App..." in your metro console.